### PR TITLE
add bundle to coreml api request

### DIFF
--- a/Sources/Roboflow/Classes/Roboflow.swift
+++ b/Sources/Roboflow/Classes/Roboflow.swift
@@ -83,7 +83,7 @@ public class RoboflowMobile: NSObject {
     }
     
     func getConfigData(modelName: String, modelVersion: Int, apiKey: String, deviceID: String, completion: @escaping (([String: Any]?, Error?) -> Void)) {
-        var request = URLRequest(url: URL(string: "https://api.roboflow.com/coreml/\(modelName)/\(String(modelVersion))?api_key=\(apiKey)&device=\(deviceID)")!,timeoutInterval: Double.infinity)
+        var request = URLRequest(url: URL(string: "https://api.roboflow.com/coreml/\(modelName)/\(String(modelVersion))?api_key=\(apiKey)&device=\(deviceID)&bundle=\(String(describing: Bundle.main.bundleIdentifier))")!,timeoutInterval: Double.infinity)
         request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpMethod = "GET"
         


### PR DESCRIPTION
# Description
This change adds the app bundle identifier to the request made from the sdk to the coreml api route in order to download weights. This change was made to increase usage visibility by also tracking apps in addition to devices and to allow us to distinguish between requests from the official roboflow mobile app and others.

Please include a summary of the change and which issue is fixed or implemented. Please also include relevant motivation and context (e.g. links, docs, tickets etc.).

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

This was tested using a test app.

## Any specific deployment considerations

For example, documentation changes, usability, usage/costs, secrets, etc.

## Docs

-   [ ] Docs updated? What were the changes:
