### PR TITLE
Add api call

### DIFF
--- a/Roboflow.podspec
+++ b/Roboflow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name               = "Roboflow"
-  spec.version            = "1.1.19"
+  spec.version            = "1.1.20"
   spec.platform           = :ios, '15.2'
   spec.ios.deployment_target = '15.2'
   spec.summary            = "A framework for interfacing with Roboflow"

--- a/Sources/Roboflow/Classes/Roboflow.swift
+++ b/Sources/Roboflow/Classes/Roboflow.swift
@@ -37,6 +37,9 @@ public class RoboflowMobile: NSObject {
             let colors = modelInfo["colors"] as? [String: String],
             let name = modelInfo["name"] as? String,
             let modelType = modelInfo["modelType"] as? String {
+            
+            getConfigDataBackground(modelName: model, modelVersion: modelVersion, apiKey: apiKey, deviceID: deviceID)
+            
             let objectDetectionModel = RFObjectDetectionModel()
 
             do {
@@ -45,7 +48,7 @@ public class RoboflowMobile: NSObject {
                                                                 appropriateFor: nil,
                                                                 create: false)
                 _ = objectDetectionModel.loadMLModel(modelPath: documentsURL.appendingPathComponent(modelURL), colors: colors)
-
+                
                 completion(objectDetectionModel, nil, name, modelType)
             } catch {
                 clearAndRetryLoadingModel(model, modelVersion, completion)
@@ -107,6 +110,12 @@ public class RoboflowMobile: NSObject {
                 completion(nil, error.localizedDescription)
             }
         }).resume()
+    }
+    
+    private func getConfigDataBackground(modelName: String, modelVersion: Int, apiKey: String, deviceID: String) {
+        DispatchQueue.global(qos: .background).async {
+            getConfigData(modelName: modelName, modelVersion: modelVersion, apiKey: apiKey, deviceID: deviceID, completion: {})
+        }
     }
     
     

--- a/Sources/Roboflow/Classes/Roboflow.swift
+++ b/Sources/Roboflow/Classes/Roboflow.swift
@@ -114,7 +114,7 @@ public class RoboflowMobile: NSObject {
     
     private func getConfigDataBackground(modelName: String, modelVersion: Int, apiKey: String, deviceID: String) {
         DispatchQueue.global(qos: .background).async {
-            getConfigData(modelName: modelName, modelVersion: modelVersion, apiKey: apiKey, deviceID: deviceID, completion: {})
+            self.getConfigData(modelName: modelName, modelVersion: modelVersion, apiKey: apiKey, deviceID: deviceID, completion: {_,_ in })
         }
     }
     


### PR DESCRIPTION
# Description
This change adds an API call in the background if using cached weights for billing purposes. This is a soft call so if it fails the app works as normal in offline mode.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] This change requires a documentation update

## How has this change been tested, please provide a testcase or example of how you tested the change?

I tested using the sample iOS app running on my iPhone and used debug breakpoints to make sure the correct calls were made upon caching weights.
