### PR TITLE
Fix baseptr warning

### DIFF
--- a/Roboflow.podspec
+++ b/Roboflow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name               = "Roboflow"
-  spec.version            = "1.2.0"
+  spec.version            = "1.2.1"
   spec.platform           = :ios, '15.2'
   spec.ios.deployment_target = '15.2'
   spec.summary            = "A framework for interfacing with Roboflow"


### PR DESCRIPTION
# Description

fix small warning with incorrect use of non-sendable pointer. caught when using `pod lib lint`.

List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

tested using the Roboflow iOS Starter app.
