### PR TITLE
Support models with class names not embedded

### DIFF
--- a/Sources/Roboflow/Classes/core/RFObjectDetectionModel.swift
+++ b/Sources/Roboflow/Classes/core/RFObjectDetectionModel.swift
@@ -88,7 +88,13 @@ public class RFObjectDetectionModel: RFModel {
                 var label:String = ""
                 if #available(macOS 10.14, *) {
                     if let recognizedResult = detectResult as? VNRecognizedObjectObservation, let classLabel = recognizedResult.labels.first?.identifier {
-                        label = classLabel
+                        // class labels may be stripped from the model when weights trained externally and uploaded.
+                        // if our class it is an integer and it is not a defined class, look it up in our class map.
+                        if let intValue = Int(classLabel), !classes.contains(classLabel), intValue < classes.count {
+                            label = classes[intValue]
+                        } else {
+                            label = classLabel
+                        }
                     }
                 } else {
                     // Fallback on earlier versions


### PR DESCRIPTION
# Description

When model weights are uploaded to the roboflow platform, the class names can be stripped for security reasons. In this case, the `identifier` on the `VNRecognizedObjectObservation` is a numeric value ie `"14"` rather than an actual class name ie `"dog"`.

With this change, when we get a numeric class identifier, we will first make sure that the number is not a valid class label, in case a model is being labeled with numbers. We then look up the class mapping corresponding to the integer value and return it.


## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locally

## Any specific deployment considerations

standard deploy

## Docs

-   n/a
