### PR TITLE
Choose largest polygon when converting masks to polygon

### DIFF
--- a/.github/workflows/publish-pod.yml
+++ b/.github/workflows/publish-pod.yml
@@ -6,6 +6,12 @@ on:
     paths:
       - 'Roboflow.podspec'
   workflow_dispatch:
+    inputs:
+      force_tag:
+        description: 'Allow republish of existing tag (use with caution)'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   publish:
@@ -18,13 +24,18 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Fetch all tags
-    
+
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1.6.0
+      with:
+        xcode-version: 'latest-stable'
+
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2'
         bundler-cache: false
-    
+
     - name: Install CocoaPods
       run: |
         gem install cocoapods
@@ -39,33 +50,37 @@ jobs:
     
     - name: Validate podspec
       run: |
+        echo "Setting up iOS simulator..."
+        xcrun simctl list devices
+        echo ""
         echo "Linting pod..."
         pod lib lint
     
-    - name: Check if should publish
-      id: check_publish
-      run: |
-        # Check if tag already exists
-        if git rev-parse "${{ steps.get_version.outputs.VERSION }}" >/dev/null 2>&1; then
-          echo "Tag ${{ steps.get_version.outputs.VERSION }} already exists - will skip publishing"
-          echo "SHOULD_PUBLISH=false" >> $GITHUB_OUTPUT
-        else
-          echo "Tag ${{ steps.get_version.outputs.VERSION }} does not exist - will proceed with publishing"
-          echo "SHOULD_PUBLISH=true" >> $GITHUB_OUTPUT
-        fi
-    
     - name: Create and push tag
-      if: steps.check_publish.outputs.SHOULD_PUBLISH
       run: |
         echo "Creating tag for version ${{ steps.get_version.outputs.VERSION }}..."
         git config user.name github-actions
         git config user.email github-actions@github.com
-        git tag "${{ steps.get_version.outputs.VERSION }}"
-        git push origin "${{ steps.get_version.outputs.VERSION }}"
-        echo "Created and pushed tag: ${{ steps.get_version.outputs.VERSION }}"
+
+        # Check if tag already exists remotely
+        if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.get_version.outputs.VERSION }}$"; then
+          if [[ "${{ github.event.inputs.force_tag }}" == "true" ]]; then
+            echo "Tag ${{ steps.get_version.outputs.VERSION }} already exists. Force push enabled, overwriting..."
+            git tag -f "${{ steps.get_version.outputs.VERSION }}"
+            git push origin "${{ steps.get_version.outputs.VERSION }}" --force
+            echo "Force pushed tag: ${{ steps.get_version.outputs.VERSION }}"
+          else
+            echo "Error: Tag ${{ steps.get_version.outputs.VERSION }} already exists and force push is not enabled."
+            echo "To overwrite, run the workflow manually with 'Allow republish of existing tag' option checked."
+            exit 1
+          fi
+        else
+          git tag "${{ steps.get_version.outputs.VERSION }}"
+          git push origin "${{ steps.get_version.outputs.VERSION }}"
+          echo "Created and pushed new tag: ${{ steps.get_version.outputs.VERSION }}"
+        fi
     
     - name: Publish to CocoaPods
-      if: steps.check_publish.outputs.SHOULD_PUBLISH
       env:
         COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
       run: |

--- a/Roboflow.podspec
+++ b/Roboflow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name               = "Roboflow"
-  spec.version            = "1.2.5"
+  spec.version            = "1.2.6"
   spec.platform           = :ios, '15.2'
   spec.ios.deployment_target = '15.2'
   spec.summary            = "A framework for interfacing with Roboflow"

--- a/Roboflow.podspec
+++ b/Roboflow.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name               = "Roboflow"
-  spec.version            = "1.2.6"
+  spec.version            = "1.2.7"
   spec.platform           = :ios, '15.2'
   spec.ios.deployment_target = '15.2'
   spec.summary            = "A framework for interfacing with Roboflow"

--- a/Sources/Roboflow/Classes/core/RFInstanceSegmentationModel.swift
+++ b/Sources/Roboflow/Classes/core/RFInstanceSegmentationModel.swift
@@ -204,7 +204,12 @@ public class RFInstanceSegmentationModel: RFObjectDetectionModel {
                         print(error)
                     }
                     
-                    var polygon = (polys.count > 0 ? polys[0] : [])
+                    // Select largest contour: If multiple contours exist, picks the one with the most points
+                    // using max(by:) to match Python's argmax behavior
+                    var polygon: [CGPoint] = []
+                    if !polys.isEmpty {
+                        polygon = polys.max(by: { $0.count < $1.count }) ?? []
+                    }
                     
                     if polygon.count > maskMaxNumberPoints {
                         // ── 1. Decide which vertices to drop ──────────────────────────


### PR DESCRIPTION
# Description

When converting segmentation masks to polys, the current algorithm is to choose the first contour found. This logic causes erroneous behavior which sometimes chooses small contours to be selected.

With this change, we use the same [logic from inference](https://github.com/roboflow/inference/blob/8f5716fcb72d53f371180dc462678c138782e586/inference/core/utils/postprocess.py#L73), which picks the largest contour for conversion.

Also fixes some issues with release process github actions.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)

## How has this change been tested, please provide a testcase or example of how you tested the change?

Tested locallly

## Any specific deployment considerations

Standard deploy

## Docs

-   [x] Docs updated? What were the changes:
