### PR TITLE
Add support for rfdetr instance segmentation

### DIFF
--- a/Sources/Roboflow/Classes/Roboflow.swift
+++ b/Sources/Roboflow/Classes/Roboflow.swift
@@ -41,6 +41,12 @@ public class RoboflowMobile: NSObject {
     }
     
     func getModelClass(modelType: String) -> RFModel {
+        // RF-DETR segmentation emits boxes/scores/labels/masks — distinct from the
+        // YOLOv8-seg layout — so it needs its own decoder. Check it before the
+        // generic `seg` branch since the modelType contains both "detr" and "seg".
+        if (modelType.contains("detr") && modelType.contains("seg")) {
+            return RFDetrInstanceSegmentationModel()
+        }
         if (modelType.contains("seg")) {
             return RFInstanceSegmentationModel()
         }

--- a/Sources/Roboflow/Classes/Utils/MaskUtils.swift
+++ b/Sources/Roboflow/Classes/Utils/MaskUtils.swift
@@ -28,8 +28,16 @@ struct MaskUtils {
         procH: Int, procW: Int // processing height and width
     ) -> MLTensor? {
         let (c, mh, mw) = protoShape
-        let shapedProto = MLShapedArray<Float>(proto)
-        var masks = MLTensor(shapedProto)
+        // The proto output can be Float16 or Float32 depending on the exported model.
+        // MLShapedArray<Float> can only wrap a Float32-backed MLMultiArray, so for a
+        // Float16 proto we wrap it as Float16 and cast the tensor up to Float32.
+        var masks: MLTensor
+        switch proto.dataType {
+        case .float16:
+            masks = MLTensor(MLShapedArray<Float16>(proto)).cast(to: Float.self)
+        default:
+            masks = MLTensor(MLShapedArray<Float>(proto))
+        }
         masks = masks.reshaped(to: [c, mh * mw])
         
         let rows = coeffs.count

--- a/Sources/Roboflow/Classes/Utils/MaskUtils.swift
+++ b/Sources/Roboflow/Classes/Utils/MaskUtils.swift
@@ -195,10 +195,16 @@ struct MaskUtils {
     }
     
     /// parse a binary mask (0 or 255) to a set of border points that create a polygon outlining the mask's contour
-    static func maskToPolygons(
-        m: [UInt8],
-        width: Int,
-        h: Int) throws -> [[CGPoint]] {
+    static func maskToPolygons(m: [UInt8], width: Int, h: Int) throws -> [[CGPoint]] {
+        return try maskContourPolygons(m: m, width: width, h: h)
+    }
+}
+
+/// Parse a binary mask (0 or 255) into polygon contour rings, in pixel space of width×h
+/// with a top-left origin. Vision/CoreGraphics only (no MLTensor), so available below
+/// iOS 18 — shared by the YOLOv8-seg and RF-DETR-seg decoders.
+@available(macOS 13.0, iOS 16.0, *)
+func maskContourPolygons(m: [UInt8], width: Int, h: Int) throws -> [[CGPoint]] {
         var mask = m
         var height = h
         if width * height != mask.count {
@@ -253,7 +259,6 @@ struct MaskUtils {
             polygons.append(ring)
         }
         return polygons
-    }
 }
 
 /// materialize a MLTensor to a MLShapedArray for further processing

--- a/Sources/Roboflow/Classes/core/RFDetrInstanceSegmentationModel.swift
+++ b/Sources/Roboflow/Classes/core/RFDetrInstanceSegmentationModel.swift
@@ -19,7 +19,6 @@
 import Foundation
 import CoreML
 import Vision
-import Accelerate
 
 public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
 
@@ -31,7 +30,7 @@ public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
     // VNCoreMLRequest setup) — the extra `masks` output is just read at detect time.
 
     public override func detect(pixelBuffer buffer: CVPixelBuffer, completion: @escaping (([RFPrediction]?, Error?) -> Void)) {
-        guard #available(macOS 15.0, iOS 18.0, *) else {
+        guard #available(macOS 13.0, iOS 16.0, *) else {
             completion(nil, UnsupportedOSError())
             return
         }
@@ -82,7 +81,7 @@ public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
         }
     }
 
-    @available(macOS 15.0, iOS 18.0, *)
+    @available(macOS 13.0, iOS 16.0, *)
     private func processOutputs(boxes: MLMultiArray, scores: MLMultiArray, labels: MLMultiArray,
                                 masks: MLMultiArray, imageWidth: Int, imageHeight: Int) throws -> [RFInstanceSegmentationPrediction] {
         let numDet = scores.shape[1].intValue
@@ -133,8 +132,9 @@ public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
 
             // Resize logits to (outH, outW) THEN threshold at 0 — matches the reference
             // (resize-then-threshold), avoiding coarse-grid contour artifacts.
-            var polygon = maskPolygon(logits: logits, maskH: maskH, maskW: maskW,
-                                      outH: outH, outW: outW)
+            let bin = bilinearBinary(logits: logits, maskH: maskH, maskW: maskW, outH: outH, outW: outW)
+            let polys = (try? maskContourPolygons(m: bin, width: outW, h: outH)) ?? []
+            var polygon = polys.max(by: { $0.count < $1.count }) ?? []
 
             // Downsample to maskMaxNumberPoints (same scheme as the YOLOv8-seg path).
             if polygon.count > maskMaxNumberPoints {
@@ -163,28 +163,35 @@ public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
         return detections
     }
 
-    /// Bilinearly resize raw mask logits [Hm, Wm] to (outH, outW), threshold at logit > 0
-    /// (== sigmoid > 0.5), then trace the largest contour. Mirrors lwdetr.py's
-    /// F.interpolate(..., mode="bilinear", align_corners=False) > 0.0. Returns contour
-    /// points in the (outH, outW) grid (top-left origin); the caller scales to image space.
-    @available(macOS 15.0, iOS 18.0, *)
-    private func maskPolygon(logits: [Float], maskH: Int, maskW: Int, outH: Int, outW: Int) -> [CGPoint] {
-        let shaped = MLShapedArray<Float>(scalars: logits, shape: [1, maskH, maskW])
-        let bin255: MLTensor = withMLTensorComputePolicy(anePreferred) {
-            var t = MLTensor(shaped)                                                  // [1, Hm, Wm]
-            t = t.resized(to: (outH, outW), method: .bilinear(alignCorners: false))   // [1, outH, outW]
-            return (t .> Float(0)) * Float(255)                                       // resize THEN threshold
-        }
-        guard let arr = try? shapedArraySync(bin255, as: Float.self) else { return [] }
-
+    /// CPU bilinear resize of raw mask logits [Hm, Wm] to (outH, outW) with
+    /// align_corners=False coordinate mapping (matches F.interpolate / MLTensor bilinear),
+    /// then threshold at logit > 0 (== sigmoid > 0.5) into a 0/255 mask. iOS-anywhere.
+    private func bilinearBinary(logits: [Float], maskH: Int, maskW: Int, outH: Int, outW: Int) -> [UInt8] {
         var bin = [UInt8](repeating: 0, count: outH * outW)
-        arr.scalars.withUnsafeBufferPointer { src in
+        let scaleX = Float(maskW) / Float(outW)
+        let scaleY = Float(maskH) / Float(outH)
+        logits.withUnsafeBufferPointer { src in
             bin.withUnsafeMutableBufferPointer { dst in
-                vDSP_vfixu8(src.baseAddress!, 1, dst.baseAddress!, 1, vDSP_Length(outH * outW))
+                for oy in 0..<outH {
+                    // align_corners=False: src = (o + 0.5) * scale - 0.5, clamped to [0, size-1].
+                    let syf = max(0, (Float(oy) + 0.5) * scaleY - 0.5)
+                    let y0 = min(Int(syf), maskH - 1)
+                    let y1 = min(y0 + 1, maskH - 1)
+                    let wy = syf - Float(y0)
+                    let row0 = y0 * maskW, row1 = y1 * maskW
+                    for ox in 0..<outW {
+                        let sxf = max(0, (Float(ox) + 0.5) * scaleX - 0.5)
+                        let x0 = min(Int(sxf), maskW - 1)
+                        let x1 = min(x0 + 1, maskW - 1)
+                        let wx = sxf - Float(x0)
+                        let top = src[row0 + x0] + (src[row0 + x1] - src[row0 + x0]) * wx
+                        let bot = src[row1 + x0] + (src[row1 + x1] - src[row1 + x0]) * wx
+                        let v = top + (bot - top) * wy
+                        dst[oy * outW + ox] = v > 0 ? 255 : 0
+                    }
+                }
             }
         }
-
-        let polys = (try? MaskUtils.maskToPolygons(m: bin, width: outW, h: outH)) ?? []
-        return polys.max(by: { $0.count < $1.count }) ?? []
+        return bin
     }
 }

--- a/Sources/Roboflow/Classes/core/RFDetrInstanceSegmentationModel.swift
+++ b/Sources/Roboflow/Classes/core/RFDetrInstanceSegmentationModel.swift
@@ -19,6 +19,7 @@
 import Foundation
 import CoreML
 import Vision
+import Accelerate
 
 public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
 
@@ -81,14 +82,27 @@ public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
         }
     }
 
+    @available(macOS 15.0, iOS 18.0, *)
     private func processOutputs(boxes: MLMultiArray, scores: MLMultiArray, labels: MLMultiArray,
                                 masks: MLMultiArray, imageWidth: Int, imageHeight: Int) throws -> [RFInstanceSegmentationPrediction] {
         let numDet = scores.shape[1].intValue
         let maskH  = masks.shape[2].intValue   // Hm
         let maskW  = masks.shape[3].intValue   // Wm
-        // Each mask covers the full image, so map mask-grid pixels straight to image pixels.
-        let sx = Float(imageWidth)  / Float(maskW)
-        let sy = Float(imageHeight) / Float(maskH)
+
+        // Reference postprocessing (lwdetr.py) bilinearly resizes the raw mask logits to
+        // the target image size and thresholds at logit > 0. We mirror that, but resize to
+        // a processing resolution chosen by maskProcessingMode (matching the YOLOv8-seg
+        // path) to bound cost; .quality resizes to full image size like the reference.
+        let outW: Int
+        let outH: Int
+        switch maskProcessingMode {
+        case .performance: outW = max(1, imageWidth / 2); outH = max(1, imageHeight / 2)
+        case .balanced:    outW = 640;                    outH = 640
+        case .quality:     outW = imageWidth;             outH = imageHeight
+        }
+        // Mask is full-image extent resized to (outH, outW); scale contour pts back to image.
+        let sx = Float(imageWidth)  / Float(outW)
+        let sy = Float(imageHeight) / Float(outH)
 
         var detections: [RFInstanceSegmentationPrediction] = []
 
@@ -109,21 +123,18 @@ public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
             let box = CGRect(x: CGFloat(cx - w / 2), y: CGFloat(cy - h / 2),
                              width: CGFloat(w), height: CGFloat(h))
 
-            // Mask: sigmoid(logits) > 0.5 -> binary 0/255 grid, then trace polygon.
-            var bin = [UInt8](repeating: 0, count: maskH * maskW)
+            // Read this query's raw mask logits [Hm, Wm].
+            var logits = [Float](repeating: 0, count: maskH * maskW)
             for r in 0..<maskH {
                 for c in 0..<maskW {
-                    let logit = Float(masks[[0, i, r, c] as [NSNumber]].doubleValue)
-                    let prob = 1.0 / (1.0 + exp(-logit))
-                    bin[r * maskW + c] = prob > 0.5 ? 255 : 0
+                    logits[r * maskW + c] = Float(masks[[0, i, r, c] as [NSNumber]].doubleValue)
                 }
             }
 
-            var polygon: [CGPoint] = []
-            if #available(iOS 18.0, macOS 15.0, *) {
-                let polys = (try? MaskUtils.maskToPolygons(m: bin, width: maskW, h: maskH)) ?? []
-                polygon = polys.max(by: { $0.count < $1.count }) ?? []
-            }
+            // Resize logits to (outH, outW) THEN threshold at 0 — matches the reference
+            // (resize-then-threshold), avoiding coarse-grid contour artifacts.
+            var polygon = maskPolygon(logits: logits, maskH: maskH, maskW: maskW,
+                                      outH: outH, outW: outW)
 
             // Downsample to maskMaxNumberPoints (same scheme as the YOLOv8-seg path).
             if polygon.count > maskMaxNumberPoints {
@@ -150,5 +161,30 @@ public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
         }
 
         return detections
+    }
+
+    /// Bilinearly resize raw mask logits [Hm, Wm] to (outH, outW), threshold at logit > 0
+    /// (== sigmoid > 0.5), then trace the largest contour. Mirrors lwdetr.py's
+    /// F.interpolate(..., mode="bilinear", align_corners=False) > 0.0. Returns contour
+    /// points in the (outH, outW) grid (top-left origin); the caller scales to image space.
+    @available(macOS 15.0, iOS 18.0, *)
+    private func maskPolygon(logits: [Float], maskH: Int, maskW: Int, outH: Int, outW: Int) -> [CGPoint] {
+        let shaped = MLShapedArray<Float>(scalars: logits, shape: [1, maskH, maskW])
+        let bin255: MLTensor = withMLTensorComputePolicy(anePreferred) {
+            var t = MLTensor(shaped)                                                  // [1, Hm, Wm]
+            t = t.resized(to: (outH, outW), method: .bilinear(alignCorners: false))   // [1, outH, outW]
+            return (t .> Float(0)) * Float(255)                                       // resize THEN threshold
+        }
+        guard let arr = try? shapedArraySync(bin255, as: Float.self) else { return [] }
+
+        var bin = [UInt8](repeating: 0, count: outH * outW)
+        arr.scalars.withUnsafeBufferPointer { src in
+            bin.withUnsafeMutableBufferPointer { dst in
+                vDSP_vfixu8(src.baseAddress!, 1, dst.baseAddress!, 1, vDSP_Length(outH * outW))
+            }
+        }
+
+        let polys = (try? MaskUtils.maskToPolygons(m: bin, width: outW, h: outH)) ?? []
+        return polys.max(by: { $0.count < $1.count }) ?? []
     }
 }

--- a/Sources/Roboflow/Classes/core/RFDetrInstanceSegmentationModel.swift
+++ b/Sources/Roboflow/Classes/core/RFDetrInstanceSegmentationModel.swift
@@ -1,0 +1,154 @@
+//
+//  RFDetrInstanceSegmentationModel.swift
+//  Roboflow
+//
+//  Instance segmentation for RF-DETR CoreML exports.
+//
+//  RF-DETR seg exports emit four named outputs (see rfdetr_coreml.py):
+//    boxes  [1, K, 4]      normalized cxcywh
+//    scores [1, K]         confidence (sigmoid already applied via top-k)
+//    labels [1, K]         class index
+//    masks  [1, K, Hm, Wm] raw mask logits at resolution / mask_downsample_ratio
+//
+//  This differs entirely from the YOLOv8-seg layout handled by
+//  RFInstanceSegmentationModel, so it gets its own decoder. Box/score/label
+//  parsing mirrors RFDetrObjectDetectionModel; we additionally sigmoid each
+//  per-query mask, threshold it, and trace a polygon contour.
+//
+
+import Foundation
+import CoreML
+import Vision
+
+public class RFDetrInstanceSegmentationModel: RFDetrObjectDetectionModel {
+
+    public override init() {
+        super.init()
+    }
+
+    // Loading is identical to RF-DETR detection (same RFDetr wrapper, same
+    // VNCoreMLRequest setup) — the extra `masks` output is just read at detect time.
+
+    public override func detect(pixelBuffer buffer: CVPixelBuffer, completion: @escaping (([RFPrediction]?, Error?) -> Void)) {
+        guard #available(macOS 15.0, iOS 18.0, *) else {
+            completion(nil, UnsupportedOSError())
+            return
+        }
+        guard let coreMLRequest = self.coreMLRequest else {
+            completion(nil, NSError(domain: "RFDetrInstanceSegmentationModel", code: 1,
+                                    userInfo: [NSLocalizedDescriptionKey: "VNCoreML model initialization failed."]))
+            return
+        }
+
+        let handler = VNImageRequestHandler(cvPixelBuffer: buffer)
+        do {
+            try handler.perform([coreMLRequest])
+
+            guard let results = coreMLRequest.results as? [VNCoreMLFeatureValueObservation] else {
+                completion(nil, NSError(domain: "RFDetrInstanceSegmentationModel", code: 2,
+                                        userInfo: [NSLocalizedDescriptionKey: "Failed to get RF-DETR seg model outputs"]))
+                return
+            }
+
+            var boxes: MLMultiArray?
+            var scores: MLMultiArray?
+            var labels: MLMultiArray?
+            var masks: MLMultiArray?
+            for result in results {
+                switch result.featureName {
+                case "boxes":  boxes  = result.featureValue.multiArrayValue
+                case "scores": scores = result.featureValue.multiArrayValue
+                case "labels": labels = result.featureValue.multiArrayValue
+                case "masks":  masks  = result.featureValue.multiArrayValue
+                default:       break
+                }
+            }
+
+            guard let boxesArray = boxes, let scoresArray = scores,
+                  let labelsArray = labels, let masksArray = masks else {
+                completion(nil, NSError(domain: "RFDetrInstanceSegmentationModel", code: 3,
+                                        userInfo: [NSLocalizedDescriptionKey: "Missing required RF-DETR seg outputs (boxes, scores, labels, masks)"]))
+                return
+            }
+
+            let detections = try processOutputs(boxes: boxesArray, scores: scoresArray,
+                                                 labels: labelsArray, masks: masksArray,
+                                                 imageWidth: Int(buffer.width()),
+                                                 imageHeight: Int(buffer.height()))
+            completion(detections, nil)
+        } catch {
+            completion(nil, error)
+        }
+    }
+
+    private func processOutputs(boxes: MLMultiArray, scores: MLMultiArray, labels: MLMultiArray,
+                                masks: MLMultiArray, imageWidth: Int, imageHeight: Int) throws -> [RFInstanceSegmentationPrediction] {
+        let numDet = scores.shape[1].intValue
+        let maskH  = masks.shape[2].intValue   // Hm
+        let maskW  = masks.shape[3].intValue   // Wm
+        // Each mask covers the full image, so map mask-grid pixels straight to image pixels.
+        let sx = Float(imageWidth)  / Float(maskW)
+        let sy = Float(imageHeight) / Float(maskH)
+
+        var detections: [RFInstanceSegmentationPrediction] = []
+
+        for i in 0..<numDet {
+            let confidence = Float(scores[[0, i] as [NSNumber]].doubleValue)
+            if confidence < Float(threshold) { continue }
+
+            let classIndex = Int(labels[[0, i] as [NSNumber]].int32Value)
+            let className = classIndex < classes.count ? classes[classIndex] : "unknown"
+
+            // Box: normalized cxcywh -> pixel xywh
+            let cx = Float(boxes[[0, i, 0] as [NSNumber]].doubleValue) * Float(imageWidth)
+            let cy = Float(boxes[[0, i, 1] as [NSNumber]].doubleValue) * Float(imageHeight)
+            let w  = abs(Float(boxes[[0, i, 2] as [NSNumber]].doubleValue)) * Float(imageWidth)
+            let h  = abs(Float(boxes[[0, i, 3] as [NSNumber]].doubleValue)) * Float(imageHeight)
+            if w <= 0 || h <= 0 { continue }
+
+            let box = CGRect(x: CGFloat(cx - w / 2), y: CGFloat(cy - h / 2),
+                             width: CGFloat(w), height: CGFloat(h))
+
+            // Mask: sigmoid(logits) > 0.5 -> binary 0/255 grid, then trace polygon.
+            var bin = [UInt8](repeating: 0, count: maskH * maskW)
+            for r in 0..<maskH {
+                for c in 0..<maskW {
+                    let logit = Float(masks[[0, i, r, c] as [NSNumber]].doubleValue)
+                    let prob = 1.0 / (1.0 + exp(-logit))
+                    bin[r * maskW + c] = prob > 0.5 ? 255 : 0
+                }
+            }
+
+            var polygon: [CGPoint] = []
+            if #available(iOS 18.0, macOS 15.0, *) {
+                let polys = (try? MaskUtils.maskToPolygons(m: bin, width: maskW, h: maskH)) ?? []
+                polygon = polys.max(by: { $0.count < $1.count }) ?? []
+            }
+
+            // Downsample to maskMaxNumberPoints (same scheme as the YOLOv8-seg path).
+            if polygon.count > maskMaxNumberPoints {
+                let toKeep = maskMaxNumberPoints
+                let strideF = Double(polygon.count) / Double(toKeep)
+                var keep = [CGPoint]()
+                var cursor = strideF / 2
+                for _ in 0..<toKeep {
+                    keep.append(polygon[Int(cursor.rounded()) % polygon.count])
+                    cursor += strideF
+                }
+                polygon = keep
+            }
+
+            // Mask-grid space -> image pixel space.
+            polygon = polygon.map { CGPoint(x: CGFloat(Float($0.x) * sx),
+                                            y: CGFloat(Float($0.y) * sy)) }
+
+            let color = hexStringToCGColor(hex: colors[className] ?? "#ff0000")
+            detections.append(RFInstanceSegmentationPrediction(
+                x: cx, y: cy, width: w, height: h,
+                className: className, confidence: confidence,
+                color: color, box: box, points: polygon))
+        }
+
+        return detections
+    }
+}

--- a/Sources/Roboflow/Classes/core/RFInstanceSegmentationModel.swift
+++ b/Sources/Roboflow/Classes/core/RFInstanceSegmentationModel.swift
@@ -63,7 +63,7 @@ public class RFInstanceSegmentationModel: RFObjectDetectionModel {
             
             let pred = castDetectResults0.shape.count == 3 ? castDetectResults0 : castDetectResults1
             let proto = castDetectResults1.shape.count == 4 ? castDetectResults1 : castDetectResults0
-            
+
             let numMasks = 32
             let numCls = self.colors.count
             


### PR DESCRIPTION
## What does this PR do?

RFDETR instance segmentation models in coreml are now available. Adds SDK support for them.

## Type of Change

- New feature (non-breaking change that adds functionality)

## Testing

- [x] I have tested this change locally
- [ ] I have added/updated tests for this change

**Test details:**
<!-- Describe what tests were added/updated and what they cover -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated the documentation accordingly (if applicable)

## Additional Context

<!-- Add any other context, screenshots, or notes about the PR here -->
